### PR TITLE
Include babel-plugin-transform-strict-mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ module.exports = {
         require('babel-plugin-transform-es2015-destructuring'),
         require('babel-plugin-transform-es2015-block-scoping'),
         require('babel-plugin-transform-es2015-typeof-symbol'),
+        require('babel-plugin-transform-strict-mode'),
         [
             require('babel-plugin-transform-regenerator'),
             {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "babel-plugin-transform-es2015-destructuring": "^6.4.0",
     "babel-plugin-transform-es2015-block-scoping": "^6.4.0",
     "babel-plugin-transform-es2015-typeof-symbol": "^6.4.3",
+    "babel-plugin-transform-strict-mode": "^6.3.13",
     "babel-plugin-transform-regenerator": "^6.4.4"
   }
 }


### PR DESCRIPTION
Restores functionality that was in
babel-plugin-transform-es2015-modules-commonjs.

Resolves #3 
