### PR TITLE
Improved log in console

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ es2015WebpackPluginList = es2015PluginList.filter(function (es2015Plugin) {
 });
 
 if (es2015PluginList.length !== es2015WebpackPluginList.length + 1) {
+    console.warn('Check your plugins and that you have closed all the brackets correctly inside your webpack.config file.');
     throw new Error('Cannot remove "babel-plugin-transform-es2015-modules-commonjs" from the plugin list.');
 }
 


### PR DESCRIPTION
I was having this issue when setting up webpack 2.0 with ES6 and arrow functions. I had no idea that I removed a bracket when deleting one of my plugins and it threw an odd error. I didn't know what the case was and used a lot of time trying to figure out what went wrong. This could potentially help a lot of developers to get a clue what went wrong when transpiling webpack.config with babel through renaming (`webpack.babel.config.js`)
