### PR TITLE
Fix module resolution for npm 3+ with babel-preset-es2015 installed

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,16 +6,16 @@ var babelPresetEs2015,
 babelPresetEs2015 = require('babel-preset-es2015');
 
 try {
-    // npm ^2
-    commonJsPlugin = require('babel-preset-es2015/node_modules/babel-plugin-transform-es2015-modules-commonjs');
+    // npm ^3
+    commonJsPlugin = require('babel-plugin-transform-es2015-modules-commonjs');
 } catch (error) {
 
 }
 
 if (!commonJsPlugin) {
     try {
-        // npm ^3
-        commonJsPlugin = require('babel-plugin-transform-es2015-modules-commonjs');
+        // npm ^2
+        commonJsPlugin = require('babel-preset-es2015/node_modules/babel-plugin-transform-es2015-modules-commonjs');
     } catch (error) {
 
     }


### PR DESCRIPTION
- Reorder try/catch for resolving "babel-plugin-transform-es2015-modules-commonjs" to check npm 3+ _before_ checking npm 2+.

Issues addressed:
https://github.com/gajus/babel-preset-es2015-webpack/issues/6
https://github.com/gajus/babel-preset-es2015-webpack/issues/10

For projects that have both `babel-preset-es2015` and `babel-preset-es2015-webpack` installed on machines using npm 3+, `commonJsPlugin` is resolving to `require('babel-preset-es2015/node_modules/babel-plugin-transform-es2015-modules-commonjs');`.

The function definitions of these two files, while mostly the same, differ slightly with regard to commenting. This creates a problem when checking for equality when filtering.

```
// Loaded when using npm 3+ and babel-preset-es2015 is installed
var commonJsPluginOne = require('babel-preset-es2015/node_modules/babel-plugin-transform-es2015-modules-commonjs');

// Loaded when using npm 3+ and babel-preset-es2015 is NOT installed
var commonJsPLuginTwo = require('babel-plugin-transform-es2015-modules-commonjs');

console.log(commonJsPluginOne === commonJsPLuginTwo);
// => false
```

This creates a problem when checking for the proper object to filter out of the array. It will return true for all instances, and subsequently throw an error.

Reordering the try/catch to check for the npm 3+ dependency _first_ will allow these cases to be handled appropriately and allow `babel-plugin-transform-es2015-modules-commonjs` to properly be filtered out of the plugin list.
