### PR TITLE
Fixed issue caused by babel-preset-es2015 change. Conditional plugins…

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ if (!commonJsPlugin) {
 es2015PluginList = babelPresetEs2015.plugins;
 
 es2015WebpackPluginList = es2015PluginList.filter(function (es2015Plugin) {
-    return es2015Plugin !== commonJsPlugin;
+    return Array.isArray(es2015Plugin) ? es2015Plugin[0] !== commonJsPlugin : es2015Plugin !== commonJsPlugin;
 });
 
 if (es2015PluginList.length !== es2015WebpackPluginList.length + 1) {


### PR DESCRIPTION
… stopped being concataned (therefore unwrapped from the array).

Fixes this culprit - https://github.com/babel/babel/commit/c6354a2132c18caca18792a544105cc1e932987a#diff-a854a9360f2dd5153da7e0f8ed87c965 

More info here - https://github.com/yelouafi/redux-saga/issues/489#issuecomment-240388728
fixes yelouafi/redux-saga#489

EDIT:// Oh. I see that there is another pull request for this one. Sorry for doubling. Didnt check pull request section before, just issues and it was not there.
